### PR TITLE
scripts/fixtures: avoid fixed tags by downloading latest release by default

### DIFF
--- a/scripts/download-and-extract-fixtures.sh
+++ b/scripts/download-and-extract-fixtures.sh
@@ -2,8 +2,19 @@
 #
 # download-and-extract-fixtures.sh
 #
-# Edit these two lines to change what you fetch and where it lands:
-TAG="zkevm@v0.0.1"          # Release tag on github.com/ethereum/execution-spec-tests
+# Downloads execution spec test fixtures for zkevm.
+# By default, it fetches the latest release tag starting with 'zkevm@'.
+# An optional argument can be provided to specify an exact tag.
+#
+# Usage:
+#   ./scripts/download-and-extract-fixtures.sh [TAG]
+#
+# Example (latest):
+#   ./scripts/download-and-extract-fixtures.sh
+# Example (specific tag):
+#   ./scripts/download-and-extract-fixtures.sh zkevm@v0.0.1
+#
+
 DEST_DIR="./zkevm-fixtures"  # Folder where the tarball will be extracted
 #
 # ─────────────────────────────────────────────────────────────────────
@@ -12,6 +23,32 @@ set -euo pipefail
 
 REPO="ethereum/execution-spec-tests"
 ASSET_NAME="fixtures_zkevm.tar.gz"
+
+# Determine the tag to use
+if [ -n "${1:-}" ]; then
+  # Use the tag provided as the first argument
+  TAG="$1"
+  echo "ℹ️  Using specified tag: ${TAG}"
+else
+  # Find the latest tag with 'zkevm@' prefix
+  echo "🔎  Finding the latest release tag with prefix 'zkevm@'..."
+  LATEST_TAG=$( \
+    curl -fsSL "https://api.github.com/repos/${REPO}/tags" | \
+    jq -r '.[].name' | \
+    grep '^zkevm@' | \
+    sed 's/^zkevm@v//' | \
+    sort -V | \
+    tail -n 1 | \
+    sed 's/^/zkevm@v/' \
+  )
+  if [[ -z "${LATEST_TAG}" ]]; then
+    echo "❌  Could not find any release tags with prefix 'zkevm@' in ${REPO}" >&2
+    exit 1
+  fi
+  TAG="${LATEST_TAG}"
+  echo "ℹ️  Using latest found tag: ${TAG}"
+fi
+
 API_URL="https://api.github.com/repos/${REPO}/releases/tags/${TAG}"
 
 echo "🔎  Getting release info for ${TAG} …"


### PR DESCRIPTION
This PR makes the download script always download the latest `zkevm@vX.X.X` tag from `execution-spec-tests` repo, compared with a fixed tag. If the user wants to download a particular version, they can provide it as an argument.

Example run:
```
$ ./scripts/download-and-extract-fixtures.sh      
🔎  Finding the latest release tag with prefix 'zkevm@'...
ℹ️  Using latest found tag: zkevm@v0.0.2
🔎  Getting release info for zkevm@v0.0.2 …
⬇️  Downloading fixtures_zkevm.tar.gz …
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 4388k  100 4388k    0     0  3897k      0  0:00:01  0:00:01 --:--:-- 22.1M
📂  Extracting to ./zkevm-fixtures/
🗑️  Cleaning up fixtures_zkevm.tar.gz
✅  Fixtures ready in ./zkevm-fixtures
```
