### PR TITLE
chore: explicitly enable `kzg-rs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2309,7 +2309,7 @@ dependencies = [
 [[package]]
 name = "ef-tests"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6510,7 +6510,7 @@ checksum = "fc7c8f7f733062b66dc1c63f9db168ac0b97a9210e247fa90fdc9ad08f51b302"
 [[package]]
 name = "reth-chain-state"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6540,7 +6540,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6560,7 +6560,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6580,7 +6580,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -6591,7 +6591,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "reth-network-types",
  "reth-prune-types",
@@ -6601,7 +6601,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6614,7 +6614,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6626,7 +6626,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -6652,7 +6652,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6680,7 +6680,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6709,7 +6709,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6724,7 +6724,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6748,7 +6748,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -6759,7 +6759,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6780,7 +6780,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6796,7 +6796,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6813,7 +6813,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -6826,7 +6826,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6850,7 +6850,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -6860,7 +6860,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6883,7 +6883,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6901,7 +6901,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -6914,7 +6914,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6932,7 +6932,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "serde",
  "serde_json",
@@ -6942,7 +6942,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "bitflags 2.9.0",
  "byteorder",
@@ -6959,7 +6959,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "bindgen",
  "cc",
@@ -6968,7 +6968,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "metrics",
  "metrics-derive",
@@ -6977,7 +6977,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-primitives",
 ]
@@ -6985,7 +6985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7008,7 +7008,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7021,7 +7021,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-eip2124",
  "reth-net-banlist",
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7050,7 +7050,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -7063,7 +7063,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7082,7 +7082,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -7094,7 +7094,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7113,7 +7113,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -7126,7 +7126,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7158,7 +7158,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7205,7 +7205,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -7219,7 +7219,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -7232,7 +7232,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -7246,7 +7246,7 @@ dependencies = [
 [[package]]
 name = "reth-stateless"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7275,7 +7275,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -7286,7 +7286,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7310,7 +7310,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7326,7 +7326,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "clap",
  "eyre",
@@ -7341,7 +7341,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7366,7 +7366,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7392,7 +7392,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -7405,7 +7405,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7422,7 +7422,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.3.12"
-source = "git+https://github.com/kevaundray/reth?rev=1183a9af01ff491edd3c7a9e6cf574febce4f71d#1183a9af01ff491edd3c7a9e6cf574febce4f71d"
+source = "git+https://github.com/kevaundray/reth?rev=96de1f325d8835d589bd505b9f94507904f20963#96de1f325d8835d589bd505b9f94507904f20963"
 dependencies = [
  "zstd 0.13.3",
 ]
@@ -9071,6 +9071,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "reth-stateless",
+ "revm",
  "sp1-zkvm",
  "tracing",
  "tracing-subscriber 0.2.25",
@@ -11174,7 +11175,7 @@ dependencies = [
 [[package]]
 name = "zkm-lib"
 version = "1.0.0"
-source = "git+https://github.com/felicityin/zkMIPS.git?branch=upgrade-deps#5204e37883de7dd28108ffec7f8d6cc21cb13afe"
+source = "git+https://github.com/felicityin/zkMIPS.git?branch=upgrade-deps#67626a07502b8e4f8a3854841d485058a003df0f"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -11216,7 +11217,7 @@ dependencies = [
 [[package]]
 name = "zkm-primitives"
 version = "1.0.0"
-source = "git+https://github.com/felicityin/zkMIPS.git?branch=upgrade-deps#5204e37883de7dd28108ffec7f8d6cc21cb13afe"
+source = "git+https://github.com/felicityin/zkMIPS.git?branch=upgrade-deps#67626a07502b8e4f8a3854841d485058a003df0f"
 dependencies = [
  "bincode",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,11 +109,11 @@ zkevm-metrics = { path = "crates/metrics" }
 # reth
 # branch is kw/stateless-experiment-zkvm-benchmarks
 # NOTE: We are using a branch of a branch that has not yet been merged into master.
-ef-tests = { git = "https://github.com/kevaundray/reth", rev = "1183a9af01ff491edd3c7a9e6cf574febce4f71d" }
-reth-ethereum-primitives = { git = "https://github.com/kevaundray/reth", rev = "1183a9af01ff491edd3c7a9e6cf574febce4f71d" }
-reth-primitives-traits = { git = "https://github.com/kevaundray/reth", rev = "1183a9af01ff491edd3c7a9e6cf574febce4f71d" }
-reth-stateless = { git = "https://github.com/kevaundray/reth", rev = "1183a9af01ff491edd3c7a9e6cf574febce4f71d" }
-reth-chainspec = { git = "https://github.com/kevaundray/reth", rev = "1183a9af01ff491edd3c7a9e6cf574febce4f71d" }
+ef-tests = { git = "https://github.com/kevaundray/reth", rev = "96de1f325d8835d589bd505b9f94507904f20963" }
+reth-ethereum-primitives = { git = "https://github.com/kevaundray/reth", rev = "96de1f325d8835d589bd505b9f94507904f20963" }
+reth-primitives-traits = { git = "https://github.com/kevaundray/reth", rev = "96de1f325d8835d589bd505b9f94507904f20963" }
+reth-stateless = { git = "https://github.com/kevaundray/reth", rev = "96de1f325d8835d589bd505b9f94507904f20963" }
+reth-chainspec = { git = "https://github.com/kevaundray/reth", rev = "96de1f325d8835d589bd505b9f94507904f20963" }
 
 # alloy
 alloy-primitives = { version = "1.0.0", default-features = false, features = [

--- a/crates/zkevm-succinct/program/Cargo.toml
+++ b/crates/zkevm-succinct/program/Cargo.toml
@@ -16,6 +16,7 @@ reth-primitives-traits = { workspace = true, features = [
     "serde",
     "serde-bincode-compat",
 ] }
+revm = { version = "22.0.1", default-features = false, features = ["kzg-rs"] }
 alloy-primitives.workspace = true
 tracing-subscriber = "*"
 tracing = "*"


### PR DESCRIPTION
The reth dependency was previously enabling the kzg-rs feature which broke all other zkVMs except sp1. This enables it locally only for sp1.