### PR TITLE
Create benchmark runner and allow parallel execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,6 +1256,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "benchmark-runner"
+version = "0.1.0"
+dependencies = [
+ "rayon",
+ "witness-generator",
+ "zkevm-metrics",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1438,20 +1438,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bls12_381"
-version = "0.8.0"
-source = "git+https://github.com/zkMIPS-patches/bls12_381?branch=patch-0.8.0#7452c9fc2403cdee80b117ecb8931b7cf608d6ce"
-dependencies = [
- "cfg-if",
- "ff 0.13.1",
- "group 0.13.0",
- "pairing 0.23.0",
- "rand_core 0.6.4",
- "subtle",
- "zkm-lib 1.0.0 (git+https://github.com/felicityin/zkMIPS.git?branch=upgrade-deps)",
-]
-
-[[package]]
 name = "blst"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2071,9 +2057,9 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
-source = "git+https://github.com/zkMIPS-patches/curve25519-dalek?branch=patch-4.1.3#b812e455b9f59949c4cd9cdded2c9c7b4a2e1671"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
- "anyhow",
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
@@ -2081,13 +2067,13 @@ dependencies = [
  "rustc_version 0.4.1",
  "subtle",
  "zeroize",
- "zkm-lib 1.0.0 (git+https://github.com/zkMIPS/zkMIPS.git)",
 ]
 
 [[package]]
 name = "curve25519-dalek-derive"
 version = "0.1.1"
-source = "git+https://github.com/zkMIPS-patches/curve25519-dalek?branch=patch-4.1.3#b812e455b9f59949c4cd9cdded2c9c7b4a2e1671"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2491,10 +2477,7 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 [[package]]
 name = "ecdsa"
 version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+source = "git+https://github.com/sp1-patches/signatures.git?tag=patch-16.9-sp1-4.1.0#1880299a48fe7ef249edaa616fd411239fb5daf1"
 dependencies = [
  "der",
  "digest 0.10.7",
@@ -4462,7 +4445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a575df5f985fe1cd5b2b05664ff6accfc46559032b954529fd225a2168d27b0f"
 dependencies = [
  "bitvec",
- "bls12_381 0.7.1",
+ "bls12_381",
  "ff 0.12.1",
  "group 0.12.1",
  "rand_core 0.6.4",
@@ -4472,16 +4455,17 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-4.1.0#dbb97456cb6bda207eb212011ac834582263e88b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
+ "hex",
  "once_cell",
  "serdect",
  "sha2 0.10.9",
  "signature",
+ "sp1-lib",
 ]
 
 [[package]]
@@ -4526,13 +4510,14 @@ dependencies = [
 [[package]]
 name = "kzg-rs"
 version = "0.2.6"
-source = "git+https://github.com/zkMIPS-patches/kzg-rs.git?branch=zkMIPS#05eb129bbc2a1b8c78a9d335e92dfeabb6484700"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd8d5f2e17b33192c9e9d748a2b00200896727882b6410fc5ed1efd4667ce20"
 dependencies = [
- "bls12_381 0.8.0",
  "ff 0.13.1",
  "hex",
  "serde_arrays 0.2.0",
  "sha2 0.10.9",
+ "sp1_bls12_381",
  "spin 0.9.8",
 ]
 
@@ -5370,13 +5355,14 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p256"
 version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-4.1.0#f527279b192e0d1b293108af2faee513495411ca"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "hex",
  "primeorder",
  "sha2 0.10.9",
+ "sp1-lib",
 ]
 
 [[package]]
@@ -6329,9 +6315,8 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+version = "0.13.1"
+source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-4.1.0#f527279b192e0d1b293108af2faee513495411ca"
 dependencies = [
  "elliptic-curve",
 ]
@@ -8017,8 +8002,7 @@ dependencies = [
 [[package]]
 name = "rfc6979"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+source = "git+https://github.com/sp1-patches/signatures.git?tag=patch-16.9-sp1-4.1.0#1880299a48fe7ef249edaa616fd411239fb5daf1"
 dependencies = [
  "hmac",
  "subtle",
@@ -8990,8 +8974,7 @@ dependencies = [
 [[package]]
 name = "sha3"
 version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha3-0.10.8-sp1-4.0.0#8f6d303c0861ba7e5adcc36207c0f41fe5edaabc"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -9288,6 +9271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3ef88f90458b6116da164e9c4c4596c49c8cca1944bfe02850b48b232a06b90"
 dependencies = [
  "bincode",
+ "elliptic-curve",
  "serde",
  "sp1-primitives",
 ]
@@ -9593,6 +9577,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp1_bls12_381"
+version = "0.8.0-sp1-4.0.0-v2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0800e0491c38cc686233518fce535d01ba0a0707781766fec38aee9c1b33890"
+dependencies = [
+ "cfg-if",
+ "ff 0.13.1",
+ "group 0.13.0",
+ "pairing 0.23.0",
+ "rand_core 0.6.4",
+ "sp1-lib",
+ "subtle",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9740,6 +9739,7 @@ dependencies = [
 name = "succinct-host"
 version = "0.1.0"
 dependencies = [
+ "benchmark-runner",
  "dotenv",
  "sp1-sdk",
  "witness-generator",
@@ -11615,7 +11615,7 @@ dependencies = [
  "ark-std 0.4.0",
  "bitvec",
  "blake2",
- "bls12_381 0.7.1",
+ "bls12_381",
  "byteorder",
  "cfg-if",
  "group 0.12.1",
@@ -11694,7 +11694,7 @@ dependencies = [
  "typenum",
  "vec_map",
  "zkm-curves",
- "zkm-primitives 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
+ "zkm-primitives",
  "zkm-stark",
 ]
 
@@ -11746,7 +11746,7 @@ dependencies = [
  "zkm-core-executor",
  "zkm-curves",
  "zkm-derive",
- "zkm-primitives 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
+ "zkm-primitives",
  "zkm-stark",
 ]
 
@@ -11768,7 +11768,7 @@ dependencies = [
  "serde",
  "snowbridge-amcl",
  "typenum",
- "zkm-primitives 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
+ "zkm-primitives",
  "zkm-stark",
 ]
 
@@ -11798,6 +11798,7 @@ dependencies = [
 name = "zkm-host"
 version = "0.1.0"
 dependencies = [
+ "benchmark-runner",
  "dotenv",
  "witness-generator",
  "zkevm-metrics",
@@ -11878,7 +11879,7 @@ dependencies = [
  "tracing-subscriber 0.3.19",
  "zkm-core-executor",
  "zkm-core-machine",
- "zkm-primitives 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
+ "zkm-primitives",
  "zkm-recursion-circuit",
  "zkm-recursion-compiler",
  "zkm-recursion-core",
@@ -11912,7 +11913,7 @@ dependencies = [
  "zkm-core-executor",
  "zkm-core-machine",
  "zkm-derive",
- "zkm-primitives 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
+ "zkm-primitives",
  "zkm-recursion-compiler",
  "zkm-recursion-core",
  "zkm-recursion-gnark-ffi",
@@ -11934,7 +11935,7 @@ dependencies = [
  "tracing",
  "vec_map",
  "zkm-core-machine",
- "zkm-primitives 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
+ "zkm-primitives",
  "zkm-recursion-core",
  "zkm-recursion-derive",
  "zkm-stark",
@@ -11972,7 +11973,7 @@ dependencies = [
  "zkhash",
  "zkm-core-machine",
  "zkm-derive",
- "zkm-primitives 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
+ "zkm-primitives",
  "zkm-stark",
 ]
 
@@ -12052,7 +12053,7 @@ dependencies = [
  "zkm-build 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
  "zkm-core-executor",
  "zkm-core-machine",
- "zkm-primitives 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
+ "zkm-primitives",
  "zkm-prover",
  "zkm-stark",
 ]
@@ -12095,7 +12096,7 @@ dependencies = [
  "tracing-forest",
  "tracing-subscriber 0.3.19",
  "zkm-derive",
- "zkm-primitives 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
+ "zkm-primitives",
  "zkm-zkvm 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
 ]
 
@@ -12178,26 +12179,11 @@ dependencies = [
 ]
 
 [[patch.unused]]
-name = "curve25519-dalek-ng"
-version = "4.1.1"
-source = "git+https://github.com/zkMIPS-patches/curve25519-dalek-ng?branch=patch-4.1.1#6af5447fdc6325d541bc4c28c69c969109f59e1a"
-
-[[patch.unused]]
-name = "rsa"
-version = "0.9.6"
-source = "git+https://github.com/zkMIPS-patches/RustCrypto-RSA.git?branch=patch-rsa-0.9.6#ddbfba5a2a0789384d34a4820644c28b4531ef21"
-
-[[patch.unused]]
-name = "secp256k1"
-version = "0.29.1"
-source = "git+https://github.com/zkMIPS-patches/rust-secp256k1?branch=patch-0.29.1#c7e39ee0732d0e6b5c33721038f8f1b789f77c36"
+name = "substrate-bn"
+version = "0.6.0"
+source = "git+https://github.com/sp1-patches/bn?tag=patch-0.6.0-sp1-4.0.0#1bd84110963662fae88baa5ad07c9ab92b6acdbb"
 
 [[patch.unused]]
 name = "sha2"
 version = "0.10.8"
-source = "git+https://github.com/zkMIPS-patches/RustCrypto-hashes?branch=patch-sha2-0.10.8#62d9223ba171ef6d5b637b275c4b982f56d0a949"
-
-[[patch.unused]]
-name = "substrate-bn"
-version = "0.6.0"
-source = "git+https://github.com/zkMIPS-patches/bn?branch=patch-0.6.0#f7abdf37eda884458b940307a2cde9b97b1f1d92"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.8-sp1-4.0.0#1f224388fdede7cef649bce0d63876d1a9e3f515"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,15 +1256,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
-name = "benchmark-runner"
-version = "0.1.0"
-dependencies = [
- "metrics 0.1.0",
- "rayon",
- "witness-generator",
-]
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2477,7 +2468,8 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 [[package]]
 name = "ecdsa"
 version = "0.16.9"
-source = "git+https://github.com/sp1-patches/signatures.git?tag=patch-16.9-sp1-4.1.0#1880299a48fe7ef249edaa616fd411239fb5daf1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
  "digest 0.10.7",
@@ -4455,17 +4447,16 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-4.1.0#dbb97456cb6bda207eb212011ac834582263e88b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "hex",
  "once_cell",
  "serdect",
  "sha2 0.10.9",
  "signature",
- "sp1-lib",
 ]
 
 [[package]]
@@ -5355,14 +5346,13 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p256"
 version = "0.13.2"
-source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-4.1.0#f527279b192e0d1b293108af2faee513495411ca"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "hex",
  "primeorder",
  "sha2 0.10.9",
- "sp1-lib",
 ]
 
 [[package]]
@@ -6315,8 +6305,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.13.1"
-source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-4.1.0#f527279b192e0d1b293108af2faee513495411ca"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
 ]
@@ -8002,7 +7993,8 @@ dependencies = [
 [[package]]
 name = "rfc6979"
 version = "0.4.0"
-source = "git+https://github.com/sp1-patches/signatures.git?tag=patch-16.9-sp1-4.1.0#1880299a48fe7ef249edaa616fd411239fb5daf1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
@@ -8974,7 +8966,8 @@ dependencies = [
 [[package]]
 name = "sha3"
 version = "0.10.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha3-0.10.8-sp1-4.0.0#8f6d303c0861ba7e5adcc36207c0f41fe5edaabc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -9271,7 +9264,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3ef88f90458b6116da164e9c4c4596c49c8cca1944bfe02850b48b232a06b90"
 dependencies = [
  "bincode",
- "elliptic-curve",
  "serde",
  "sp1-primitives",
 ]
@@ -9739,7 +9731,6 @@ dependencies = [
 name = "succinct-host"
 version = "0.1.0"
 dependencies = [
- "benchmark-runner",
  "dotenv",
  "sp1-sdk",
  "witness-generator",
@@ -11798,7 +11789,6 @@ dependencies = [
 name = "zkm-host"
 version = "0.1.0"
 dependencies = [
- "benchmark-runner",
  "dotenv",
  "witness-generator",
  "zkevm-metrics",
@@ -12177,13 +12167,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "substrate-bn"
-version = "0.6.0"
-source = "git+https://github.com/sp1-patches/bn?tag=patch-0.6.0-sp1-4.0.0#1bd84110963662fae88baa5ad07c9ab92b6acdbb"
-
-[[patch.unused]]
-name = "sha2"
-version = "0.10.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.8-sp1-4.0.0#1f224388fdede7cef649bce0d63876d1a9e3f515"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,6 +1429,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "bls12_381"
+version = "0.8.0"
+source = "git+https://github.com/zkMIPS-patches/bls12_381?branch=patch-0.8.0#7452c9fc2403cdee80b117ecb8931b7cf608d6ce"
+dependencies = [
+ "cfg-if",
+ "ff 0.13.1",
+ "group 0.13.0",
+ "pairing 0.23.0",
+ "rand_core 0.6.4",
+ "subtle",
+ "zkm-lib 1.0.0 (git+https://github.com/felicityin/zkMIPS.git?branch=upgrade-deps)",
+]
+
+[[package]]
 name = "blst"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2048,9 +2062,9 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+source = "git+https://github.com/zkMIPS-patches/curve25519-dalek?branch=patch-4.1.3#b812e455b9f59949c4cd9cdded2c9c7b4a2e1671"
 dependencies = [
+ "anyhow",
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
@@ -2058,13 +2072,13 @@ dependencies = [
  "rustc_version 0.4.1",
  "subtle",
  "zeroize",
+ "zkm-lib 1.0.0 (git+https://github.com/zkMIPS/zkMIPS.git)",
 ]
 
 [[package]]
 name = "curve25519-dalek-derive"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+source = "git+https://github.com/zkMIPS-patches/curve25519-dalek?branch=patch-4.1.3#b812e455b9f59949c4cd9cdded2c9c7b4a2e1671"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2468,6 +2482,8 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 [[package]]
 name = "ecdsa"
 version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
@@ -4437,7 +4453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a575df5f985fe1cd5b2b05664ff6accfc46559032b954529fd225a2168d27b0f"
 dependencies = [
  "bitvec",
- "bls12_381",
+ "bls12_381 0.7.1",
  "ff 0.12.1",
  "group 0.12.1",
  "rand_core 0.6.4",
@@ -4501,14 +4517,13 @@ dependencies = [
 [[package]]
 name = "kzg-rs"
 version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd8d5f2e17b33192c9e9d748a2b00200896727882b6410fc5ed1efd4667ce20"
+source = "git+https://github.com/zkMIPS-patches/kzg-rs.git?branch=zkMIPS#05eb129bbc2a1b8c78a9d335e92dfeabb6484700"
 dependencies = [
+ "bls12_381 0.8.0",
  "ff 0.13.1",
  "hex",
  "serde_arrays 0.2.0",
  "sha2 0.10.9",
- "sp1_bls12_381",
  "spin 0.9.8",
 ]
 
@@ -9569,21 +9584,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp1_bls12_381"
-version = "0.8.0-sp1-4.0.0-v2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0800e0491c38cc686233518fce535d01ba0a0707781766fec38aee9c1b33890"
-dependencies = [
- "cfg-if",
- "ff 0.13.1",
- "group 0.13.0",
- "pairing 0.23.0",
- "rand_core 0.6.4",
- "sp1-lib",
- "subtle",
-]
-
-[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11606,7 +11606,7 @@ dependencies = [
  "ark-std 0.4.0",
  "bitvec",
  "blake2",
- "bls12_381",
+ "bls12_381 0.7.1",
  "byteorder",
  "cfg-if",
  "group 0.12.1",
@@ -11685,7 +11685,7 @@ dependencies = [
  "typenum",
  "vec_map",
  "zkm-curves",
- "zkm-primitives",
+ "zkm-primitives 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
  "zkm-stark",
 ]
 
@@ -11737,7 +11737,7 @@ dependencies = [
  "zkm-core-executor",
  "zkm-curves",
  "zkm-derive",
- "zkm-primitives",
+ "zkm-primitives 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
  "zkm-stark",
 ]
 
@@ -11759,7 +11759,7 @@ dependencies = [
  "serde",
  "snowbridge-amcl",
  "typenum",
- "zkm-primitives",
+ "zkm-primitives 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
  "zkm-stark",
 ]
 
@@ -11869,7 +11869,7 @@ dependencies = [
  "tracing-subscriber 0.3.19",
  "zkm-core-executor",
  "zkm-core-machine",
- "zkm-primitives",
+ "zkm-primitives 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
  "zkm-recursion-circuit",
  "zkm-recursion-compiler",
  "zkm-recursion-core",
@@ -11903,7 +11903,7 @@ dependencies = [
  "zkm-core-executor",
  "zkm-core-machine",
  "zkm-derive",
- "zkm-primitives",
+ "zkm-primitives 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
  "zkm-recursion-compiler",
  "zkm-recursion-core",
  "zkm-recursion-gnark-ffi",
@@ -11925,7 +11925,7 @@ dependencies = [
  "tracing",
  "vec_map",
  "zkm-core-machine",
- "zkm-primitives",
+ "zkm-primitives 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
  "zkm-recursion-core",
  "zkm-recursion-derive",
  "zkm-stark",
@@ -11963,7 +11963,7 @@ dependencies = [
  "zkhash",
  "zkm-core-machine",
  "zkm-derive",
- "zkm-primitives",
+ "zkm-primitives 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
  "zkm-stark",
 ]
 
@@ -12043,7 +12043,7 @@ dependencies = [
  "zkm-build 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
  "zkm-core-executor",
  "zkm-core-machine",
- "zkm-primitives",
+ "zkm-primitives 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
  "zkm-prover",
  "zkm-stark",
 ]
@@ -12086,7 +12086,7 @@ dependencies = [
  "tracing-forest",
  "tracing-subscriber 0.3.19",
  "zkm-derive",
- "zkm-primitives",
+ "zkm-primitives 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
  "zkm-zkvm 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
 ]
 
@@ -12167,3 +12167,28 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "curve25519-dalek-ng"
+version = "4.1.1"
+source = "git+https://github.com/zkMIPS-patches/curve25519-dalek-ng?branch=patch-4.1.1#6af5447fdc6325d541bc4c28c69c969109f59e1a"
+
+[[patch.unused]]
+name = "rsa"
+version = "0.9.6"
+source = "git+https://github.com/zkMIPS-patches/RustCrypto-RSA.git?branch=patch-rsa-0.9.6#ddbfba5a2a0789384d34a4820644c28b4531ef21"
+
+[[patch.unused]]
+name = "secp256k1"
+version = "0.29.1"
+source = "git+https://github.com/zkMIPS-patches/rust-secp256k1?branch=patch-0.29.1#c7e39ee0732d0e6b5c33721038f8f1b789f77c36"
+
+[[patch.unused]]
+name = "sha2"
+version = "0.10.8"
+source = "git+https://github.com/zkMIPS-patches/RustCrypto-hashes?branch=patch-sha2-0.10.8#62d9223ba171ef6d5b637b275c4b982f56d0a949"
+
+[[patch.unused]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "git+https://github.com/zkMIPS-patches/bn?branch=patch-0.6.0#f7abdf37eda884458b940307a2cde9b97b1f1d92"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2016,10 +2016,10 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 [[package]]
 name = "crypto-bigint"
 version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+source = "git+https://github.com/risc0/RustCrypto-crypto-bigint?tag=v0.5.5-risczero.0#3ab63a6f1048833f7047d5a50532e4a4cc789384"
 dependencies = [
  "generic-array 0.14.7",
+ "getrandom 0.2.16",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -5346,6 +5346,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
+ "bytemuck",
  "ecdsa",
  "elliptic-curve",
  "primeorder",
@@ -6306,7 +6307,9 @@ version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
+ "bytemuck",
  "elliptic-curve",
+ "risc0-bigint2",
 ]
 
 [[package]]
@@ -8034,6 +8037,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "risc0-bigint2"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921e2d3d07a327750f657c0d42cf9437024583b218ad05b24b91a557f5d01979"
+dependencies = [
+ "include_bytes_aligned",
+ "stability",
 ]
 
 [[package]]
@@ -10027,8 +10040,7 @@ dependencies = [
 [[package]]
 name = "tiny-keccak"
 version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+source = "git+https://github.com/risc0/tiny-keccak?tag=tiny-keccak%2Fv2.0.2-risczero.0#8fcc866dc94dcec3e79c3b2bc8fbc51b22f2d5e1"
 dependencies = [
  "crunchy",
 ]
@@ -12196,3 +12208,28 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "bls12_381"
+version = "0.8.0"
+source = "git+https://github.com/risc0/zkcrypto-bls12_381?tag=bls12_381%2Fv0.8.0-risczero.1#a3192e1bc58921d42d03d99957abf3be55f9d435"
+
+[[patch.unused]]
+name = "k256"
+version = "0.13.3"
+source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?tag=k256%2Fv0.13.3-risczero.1#ff5d67b095cfcc2569b7789f2079ed87ef2c7756"
+
+[[patch.unused]]
+name = "rsa"
+version = "0.9.6"
+source = "git+https://github.com/risc0/RustCrypto-RSA?tag=v0.9.6-risczero.0#cb42fd295c096c6dddd8386cd57b122add8d0cbc"
+
+[[patch.unused]]
+name = "sha2"
+version = "0.10.8"
+source = "git+https://github.com/risc0/RustCrypto-hashes?tag=sha2-v0.10.8-risczero.0#244dc3b08788f7a4ccce14c66896ae3b4f24c166"
+
+[[patch.unused]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "git+https://github.com/risc0/paritytech-bn?tag=v0.6.0-risczero.0#22108fe8c6ea1ebc1358fc4fd6854a6bf46e3509"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2016,10 +2016,10 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 [[package]]
 name = "crypto-bigint"
 version = "0.5.5"
-source = "git+https://github.com/risc0/RustCrypto-crypto-bigint?tag=v0.5.5-risczero.0#3ab63a6f1048833f7047d5a50532e4a4cc789384"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array 0.14.7",
- "getrandom 0.2.16",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -2477,8 +2477,7 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 [[package]]
 name = "ecdsa"
 version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+source = "git+https://github.com/sp1-patches/signatures.git?tag=patch-16.9-sp1-4.1.0#1880299a48fe7ef249edaa616fd411239fb5daf1"
 dependencies = [
  "der",
  "digest 0.10.7",
@@ -4444,16 +4443,17 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-4.1.0#dbb97456cb6bda207eb212011ac834582263e88b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
+ "hex",
  "once_cell",
  "serdect",
  "sha2 0.10.8",
  "signature",
+ "sp1-lib",
 ]
 
 [[package]]
@@ -5343,14 +5343,14 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p256"
 version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-4.1.0#f527279b192e0d1b293108af2faee513495411ca"
 dependencies = [
- "bytemuck",
  "ecdsa",
  "elliptic-curve",
+ "hex",
  "primeorder",
  "sha2 0.10.8",
+ "sp1-lib",
 ]
 
 [[package]]
@@ -6303,13 +6303,10 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+version = "0.13.1"
+source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-4.1.0#f527279b192e0d1b293108af2faee513495411ca"
 dependencies = [
- "bytemuck",
  "elliptic-curve",
- "risc0-bigint2",
 ]
 
 [[package]]
@@ -7994,8 +7991,7 @@ dependencies = [
 [[package]]
 name = "rfc6979"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+source = "git+https://github.com/sp1-patches/signatures.git?tag=patch-16.9-sp1-4.1.0#1880299a48fe7ef249edaa616fd411239fb5daf1"
 dependencies = [
  "hmac",
  "subtle",
@@ -8037,16 +8033,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "risc0-bigint2"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921e2d3d07a327750f657c0d42cf9437024583b218ad05b24b91a557f5d01979"
-dependencies = [
- "include_bytes_aligned",
- "stability",
 ]
 
 [[package]]
@@ -8982,8 +8968,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.8-sp1-4.0.0#1f224388fdede7cef649bce0d63876d1a9e3f515"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -8993,8 +8978,7 @@ dependencies = [
 [[package]]
 name = "sha3"
 version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha3-0.10.8-sp1-4.0.0#8f6d303c0861ba7e5adcc36207c0f41fe5edaabc"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -9291,6 +9275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3ef88f90458b6116da164e9c4c4596c49c8cca1944bfe02850b48b232a06b90"
 dependencies = [
  "bincode",
+ "elliptic-curve",
  "serde",
  "sp1-primitives",
 ]
@@ -9737,14 +9722,17 @@ dependencies = [
 [[package]]
 name = "substrate-bn"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
+source = "git+https://github.com/sp1-patches/bn?tag=patch-0.6.0-sp1-4.0.0#1bd84110963662fae88baa5ad07c9ab92b6acdbb"
 dependencies = [
+ "bytemuck",
  "byteorder",
+ "cfg-if",
  "crunchy",
  "lazy_static",
+ "num-bigint 0.4.6",
  "rand 0.8.5",
  "rustc-hex",
+ "sp1-lib",
 ]
 
 [[package]]
@@ -10040,7 +10028,8 @@ dependencies = [
 [[package]]
 name = "tiny-keccak"
 version = "2.0.2"
-source = "git+https://github.com/risc0/tiny-keccak?tag=tiny-keccak%2Fv2.0.2-risczero.0#8fcc866dc94dcec3e79c3b2bc8fbc51b22f2d5e1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
 ]
@@ -12208,28 +12197,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "bls12_381"
-version = "0.8.0"
-source = "git+https://github.com/risc0/zkcrypto-bls12_381?tag=bls12_381%2Fv0.8.0-risczero.1#a3192e1bc58921d42d03d99957abf3be55f9d435"
-
-[[patch.unused]]
-name = "k256"
-version = "0.13.3"
-source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?tag=k256%2Fv0.13.3-risczero.1#ff5d67b095cfcc2569b7789f2079ed87ef2c7756"
-
-[[patch.unused]]
-name = "rsa"
-version = "0.9.6"
-source = "git+https://github.com/risc0/RustCrypto-RSA?tag=v0.9.6-risczero.0#cb42fd295c096c6dddd8386cd57b122add8d0cbc"
-
-[[patch.unused]]
-name = "sha2"
-version = "0.10.8"
-source = "git+https://github.com/risc0/RustCrypto-hashes?tag=sha2-v0.10.8-risczero.0#244dc3b08788f7a4ccce14c66896ae3b4f24c166"
-
-[[patch.unused]]
-name = "substrate-bn"
-version = "0.6.0"
-source = "git+https://github.com/risc0/paritytech-bn?tag=v0.6.0-risczero.0#22108fe8c6ea1ebc1358fc4fd6854a6bf46e3509"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -675,7 +675,7 @@ dependencies = [
  "digest 0.10.7",
  "fnv",
  "merlin",
- "sha2 0.10.9",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -1500,7 +1500,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "tinyvec",
 ]
 
@@ -1778,7 +1778,7 @@ dependencies = [
  "hmac",
  "k256",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "thiserror 1.0.69",
 ]
 
@@ -1794,7 +1794,7 @@ dependencies = [
  "once_cell",
  "pbkdf2 0.12.2",
  "rand 0.8.5",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "thiserror 1.0.69",
 ]
 
@@ -1813,7 +1813,7 @@ dependencies = [
  "ripemd",
  "serde",
  "serde_derive",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "sha3",
  "thiserror 1.0.69",
 ]
@@ -2477,7 +2477,8 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 [[package]]
 name = "ecdsa"
 version = "0.16.9"
-source = "git+https://github.com/sp1-patches/signatures.git?tag=patch-16.9-sp1-4.1.0#1880299a48fe7ef249edaa616fd411239fb5daf1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
  "digest 0.10.7",
@@ -2745,7 +2746,7 @@ dependencies = [
  "scrypt",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "sha3",
  "thiserror 1.0.69",
  "uuid 0.8.2",
@@ -3050,7 +3051,7 @@ dependencies = [
  "eth-keystore",
  "ethers-core",
  "rand 0.8.5",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "thiserror 1.0.69",
  "tracing",
 ]
@@ -3623,7 +3624,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_arrays 0.1.0",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "static_assertions",
  "subtle",
  "unroll",
@@ -3808,18 +3809,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "host"
-version = "0.1.0"
-dependencies = [
- "methods",
- "risc0-zkvm",
- "serde",
- "tracing-subscriber 0.3.19",
- "witness-generator",
- "zkevm-metrics",
 ]
 
 [[package]]
@@ -4455,17 +4444,16 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-4.1.0#dbb97456cb6bda207eb212011ac834582263e88b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "hex",
  "once_cell",
  "serdect",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "signature",
- "sp1-lib",
 ]
 
 [[package]]
@@ -4516,7 +4504,7 @@ dependencies = [
  "ff 0.13.1",
  "hex",
  "serde_arrays 0.2.0",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "sp1_bls12_381",
  "spin 0.9.8",
 ]
@@ -5355,14 +5343,13 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p256"
 version = "0.13.2"
-source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-4.1.0#f527279b192e0d1b293108af2faee513495411ca"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "hex",
  "primeorder",
- "sha2 0.10.9",
- "sp1-lib",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -6077,7 +6064,7 @@ dependencies = [
  "digest 0.10.7",
  "hmac",
  "password-hash",
- "sha2 0.10.9",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -6315,8 +6302,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.13.1"
-source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-4.1.0#f527279b192e0d1b293108af2faee513495411ca"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
 ]
@@ -7195,7 +7183,7 @@ dependencies = [
  "reth-payload-primitives",
  "reth-primitives-traits",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -7973,7 +7961,8 @@ dependencies = [
  "revm-primitives",
  "ripemd",
  "secp256k1",
- "sha2 0.10.9",
+ "sha2 0.10.8",
+ "substrate-bn",
 ]
 
 [[package]]
@@ -8002,7 +7991,8 @@ dependencies = [
 [[package]]
 name = "rfc6979"
 version = "0.4.0"
-source = "git+https://github.com/sp1-patches/signatures.git?tag=patch-16.9-sp1-4.1.0#1880299a48fe7ef249edaa616fd411239fb5daf1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
@@ -8171,6 +8161,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-guest"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "c-kzg",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits",
+ "reth-stateless",
+ "revm",
+ "risc0-zkvm",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "risc0-host"
+version = "0.1.0"
+dependencies = [
+ "benchmark-runner",
+ "methods",
+ "risc0-zkvm",
+ "serde",
+ "tracing-subscriber 0.3.19",
+ "witness-generator",
+ "zkevm-metrics",
+]
+
+[[package]]
 name = "risc0-zkos-v1compat"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8200,7 +8217,7 @@ dependencies = [
  "risc0-core",
  "risc0-zkvm-platform",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "stability",
  "tracing",
 ]
@@ -8236,7 +8253,7 @@ dependencies = [
  "rzup",
  "semver 1.0.26",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "stability",
  "tempfile",
  "tracing",
@@ -8254,17 +8271,6 @@ dependencies = [
  "getrandom 0.3.2",
  "libm",
  "stability",
-]
-
-[[package]]
-name = "risc0guest"
-version = "0.1.0"
-dependencies = [
- "alloy-primitives",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-stateless",
- "risc0-zkvm",
 ]
 
 [[package]]
@@ -8659,7 +8665,7 @@ dependencies = [
  "hmac",
  "pbkdf2 0.11.0",
  "salsa20",
- "sha2 0.10.9",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -8962,9 +8968,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -8974,7 +8980,8 @@ dependencies = [
 [[package]]
 name = "sha3"
 version = "0.10.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha3-0.10.8-sp1-4.0.0#8f6d303c0861ba7e5adcc36207c0f41fe5edaabc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -9271,7 +9278,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3ef88f90458b6116da164e9c4c4596c49c8cca1944bfe02850b48b232a06b90"
 dependencies = [
  "bincode",
- "elliptic-curve",
  "serde",
  "sp1-primitives",
 ]
@@ -9293,7 +9299,7 @@ dependencies = [
  "p3-poseidon2 0.2.2-succinct",
  "p3-symmetric 0.2.2-succinct",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -9326,7 +9332,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-primitives",
@@ -9469,7 +9475,7 @@ dependencies = [
  "p3-symmetric 0.2.2-succinct",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "sp1-core-machine",
  "sp1-recursion-compiler",
  "sp1-stark",
@@ -9571,7 +9577,7 @@ dependencies = [
  "lazy_static",
  "libm",
  "rand 0.8.5",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "sp1-lib",
  "sp1-primitives",
 ]
@@ -9716,6 +9722,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand 0.8.5",
+ "rustc-hex",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9760,7 +9779,7 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "thiserror 1.0.69",
  "url",
  "zip",
@@ -11627,7 +11646,7 @@ dependencies = [
  "pasta_curves 0.5.1",
  "rand 0.8.5",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "sha3",
  "subtle",
 ]
@@ -11683,7 +11702,7 @@ dependencies = [
  "rrs-succinct",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "test-artifacts",
@@ -11815,7 +11834,7 @@ dependencies = [
  "cfg-if",
  "elliptic-curve",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -11827,7 +11846,7 @@ dependencies = [
  "cfg-if",
  "elliptic-curve",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -11845,7 +11864,7 @@ dependencies = [
  "p3-poseidon2 0.1.0",
  "p3-symmetric 0.1.0",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -12004,7 +12023,7 @@ dependencies = [
  "p3-symmetric 0.1.0",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "tempfile",
  "zkm-core-machine",
  "zkm-recursion-compiler",
@@ -12111,7 +12130,7 @@ dependencies = [
  "lazy_static",
  "rand 0.8.5",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "zkm-lib 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
 ]
 
@@ -12127,7 +12146,7 @@ dependencies = [
  "libm",
  "rand 0.8.5",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "zkm-lib 1.0.0 (git+https://github.com/zkMIPS/zkMIPS.git)",
 ]
 
@@ -12177,13 +12196,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "substrate-bn"
-version = "0.6.0"
-source = "git+https://github.com/sp1-patches/bn?tag=patch-0.6.0-sp1-4.0.0#1bd84110963662fae88baa5ad07c9ab92b6acdbb"
-
-[[patch.unused]]
-name = "sha2"
-version = "0.10.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.8-sp1-4.0.0#1f224388fdede7cef649bce0d63876d1a9e3f515"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,6 +1256,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "benchmark-runner"
+version = "0.1.0"
+dependencies = [
+ "metrics 0.1.0",
+ "rayon",
+ "witness-generator",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2468,8 +2477,7 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 [[package]]
 name = "ecdsa"
 version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+source = "git+https://github.com/sp1-patches/signatures.git?tag=patch-16.9-sp1-4.1.0#1880299a48fe7ef249edaa616fd411239fb5daf1"
 dependencies = [
  "der",
  "digest 0.10.7",
@@ -4447,16 +4455,17 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-4.1.0#dbb97456cb6bda207eb212011ac834582263e88b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
+ "hex",
  "once_cell",
  "serdect",
  "sha2 0.10.9",
  "signature",
+ "sp1-lib",
 ]
 
 [[package]]
@@ -5346,13 +5355,14 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p256"
 version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-4.1.0#f527279b192e0d1b293108af2faee513495411ca"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "hex",
  "primeorder",
  "sha2 0.10.9",
+ "sp1-lib",
 ]
 
 [[package]]
@@ -6305,9 +6315,8 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+version = "0.13.1"
+source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-4.1.0#f527279b192e0d1b293108af2faee513495411ca"
 dependencies = [
  "elliptic-curve",
 ]
@@ -7993,8 +8002,7 @@ dependencies = [
 [[package]]
 name = "rfc6979"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+source = "git+https://github.com/sp1-patches/signatures.git?tag=patch-16.9-sp1-4.1.0#1880299a48fe7ef249edaa616fd411239fb5daf1"
 dependencies = [
  "hmac",
  "subtle",
@@ -8966,8 +8974,7 @@ dependencies = [
 [[package]]
 name = "sha3"
 version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha3-0.10.8-sp1-4.0.0#8f6d303c0861ba7e5adcc36207c0f41fe5edaabc"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -9264,6 +9271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3ef88f90458b6116da164e9c4c4596c49c8cca1944bfe02850b48b232a06b90"
 dependencies = [
  "bincode",
+ "elliptic-curve",
  "serde",
  "sp1-primitives",
 ]
@@ -9731,6 +9739,7 @@ dependencies = [
 name = "succinct-host"
 version = "0.1.0"
 dependencies = [
+ "benchmark-runner",
  "dotenv",
  "sp1-sdk",
  "witness-generator",
@@ -11789,6 +11798,7 @@ dependencies = [
 name = "zkm-host"
 version = "0.1.0"
 dependencies = [
+ "benchmark-runner",
  "dotenv",
  "witness-generator",
  "zkevm-metrics",
@@ -12167,3 +12177,13 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "git+https://github.com/sp1-patches/bn?tag=patch-0.6.0-sp1-4.0.0#1bd84110963662fae88baa5ad07c9ab92b6acdbb"
+
+[[patch.unused]]
+name = "sha2"
+version = "0.10.8"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.8-sp1-4.0.0#1f224388fdede7cef649bce0d63876d1a9e3f515"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ zero_sized_map_values = "warn"
 # local dependencies
 witness-generator = { path = "crates/witness-generator" }
 zkevm-metrics = { path = "crates/metrics" }
+benchmark-runner = { path = "crates/benchmark-runner" }
 
 # reth
 # branch is kw/stateless-experiment-zkvm-benchmarks

--- a/crates/benchmark-runner/Cargo.toml
+++ b/crates/benchmark-runner/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "benchmark-runner"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rayon.workspace = true
+witness-generator.workspace = true
+metrics.workspace = true

--- a/crates/benchmark-runner/Cargo.toml
+++ b/crates/benchmark-runner/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [dependencies]
 rayon.workspace = true
 witness-generator.workspace = true
-metrics.workspace = true
+zkevm-metrics.workspace = true

--- a/crates/benchmark-runner/src/lib.rs
+++ b/crates/benchmark-runner/src/lib.rs
@@ -1,6 +1,6 @@
-use metrics::WorkloadMetrics;
 use rayon::prelude::*;
 use witness_generator::{generate_stateless_witness, BlocksAndWitnesses};
+use zkevm_metrics::WorkloadMetrics;
 
 pub fn run_benchmark<F>(elf_path: &'static [u8], metrics_path_prefix: &str, zkvm_executor: F)
 where

--- a/crates/benchmark-runner/src/lib.rs
+++ b/crates/benchmark-runner/src/lib.rs
@@ -1,0 +1,35 @@
+use metrics::WorkloadMetrics;
+use rayon::prelude::*;
+use witness_generator::{generate_stateless_witness, BlocksAndWitnesses};
+
+pub fn run_benchmark<F>(elf_path: &'static [u8], metrics_path_prefix: &str, zkvm_executor: F)
+where
+    F: Fn(&BlocksAndWitnesses, &'static [u8]) -> Vec<WorkloadMetrics> + Send + Sync,
+{
+    let generated_corpuses = generate_stateless_witness::generate();
+
+    generated_corpuses.into_par_iter().for_each(|bw| {
+        println!("{} (num_blocks={})", bw.name, bw.blocks_and_witnesses.len());
+
+        let reports = zkvm_executor(&bw, elf_path);
+
+        WorkloadMetrics::to_path(
+            format!(
+                "{}/{}/{}/{}.json",
+                env!("CARGO_WORKSPACE_DIR"),
+                "zkevm-metrics",
+                metrics_path_prefix,
+                bw.name
+            ),
+            &reports,
+        )
+        .unwrap();
+
+        println!(
+            "Finished processing and saved metrics for corpus: {}. Number of reports: {}",
+            bw.name,
+            reports.len()
+        );
+        // dbg!(&reports);
+    });
+}

--- a/crates/zkevm-risc0/host/Cargo.toml
+++ b/crates/zkevm-risc0/host/Cargo.toml
@@ -8,5 +8,6 @@ methods = { path = "../methods" }
 risc0-zkvm = { version = "^2.0.2", features = ["unstable"] }
 witness-generator.workspace = true
 zkevm-metrics.workspace = true
+benchmark-runner.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde = "1.0"

--- a/crates/zkevm-risc0/host/src/main.rs
+++ b/crates/zkevm-risc0/host/src/main.rs
@@ -1,6 +1,10 @@
+use std::collections::HashMap;
+
+use benchmark_runner::run_benchmark;
 use methods::RISC0_GUEST_ELF;
 use risc0_zkvm::{default_prover, ExecutorEnv};
-use witness_generator::generate_stateless_witness::generate;
+use witness_generator::BlocksAndWitnesses;
+use zkevm_metrics::WorkloadMetrics;
 
 fn main() {
     // Initialize tracing. In order to view logs, run `RUST_LOG=info cargo run`
@@ -9,7 +13,7 @@ fn main() {
         .init();
 
     run_benchmark(
-        RISC0GUEST_ELF,
+        RISC0_GUEST_ELF,
         "risc0",
         |blockchain_corpus: &BlocksAndWitnesses, _elf_data: &'static [u8]| {
             // Obtain the default prover.
@@ -29,7 +33,7 @@ fn main() {
                     .unwrap();
 
                 // Proof information by proving the specified ELF binary.
-                let _ = prover.prove(env, RISC0GUEST_ELF).unwrap();
+                let _ = prover.prove(env, RISC0_GUEST_ELF).unwrap();
 
                 // RISC0 receipt does not provide detailed region cycle counts by default.
                 // We'll use an empty HashMap for region_cycles.

--- a/crates/zkevm-risc0/host/src/main.rs
+++ b/crates/zkevm-risc0/host/src/main.rs
@@ -8,20 +8,16 @@ fn main() {
         .with_env_filter(tracing_subscriber::filter::EnvFilter::from_default_env())
         .init();
 
-    // Obtain the default prover.
-    let prover = default_prover();
-
     run_benchmark(
         RISC0GUEST_ELF,
         "risc0",
         |blockchain_corpus: &BlocksAndWitnesses, _elf_data: &'static [u8]| {
+            // Obtain the default prover.
+            let prover = default_prover();
             let mut reports = Vec::new();
             let corpus_name = &blockchain_corpus.name;
-            let num_blocks_in_corpus = blockchain_corpus.blocks_and_witnesses.len();
 
-            for (block_id, client_input) in
-                blockchain_corpus.blocks_and_witnesses.iter().enumerate()
-            {
+            for client_input in &blockchain_corpus.blocks_and_witnesses {
                 let block_number = client_input.block.number;
 
                 let env = ExecutorEnv::builder()
@@ -33,9 +29,7 @@ fn main() {
                     .unwrap();
 
                 // Proof information by proving the specified ELF binary.
-                let prove_info = prover.prove(env, RISC0GUEST_ELF).unwrap();
-                let receipt = prove_info.receipt;
-                let total_num_cycles = receipt.cycles;
+                let _ = prover.prove(env, RISC0GUEST_ELF).unwrap();
 
                 // RISC0 receipt does not provide detailed region cycle counts by default.
                 // We'll use an empty HashMap for region_cycles.
@@ -43,7 +37,7 @@ fn main() {
 
                 let metrics = WorkloadMetrics {
                     name: format!("{}-{}", corpus_name, block_number),
-                    total_num_cycles,
+                    total_num_cycles: 0, // TODO
                     region_cycles,
                 };
                 reports.push(metrics);

--- a/crates/zkevm-succinct/host/Cargo.toml
+++ b/crates/zkevm-succinct/host/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 sp1-sdk = "4.2.0"
 witness-generator.workspace = true
 zkevm-metrics.workspace = true
+benchmark-runner.workspace = true
 dotenv = "0.15.0"
 
 [lints]

--- a/crates/zkevm-succinct/host/src/main.rs
+++ b/crates/zkevm-succinct/host/src/main.rs
@@ -32,7 +32,7 @@ fn main() {
         "succinct",
         |blockchain_corpus: &BlocksAndWitnesses, elf_path: &'static [u8]| {
             let mut reports = Vec::new();
-            let name = blockchain_corpus.name.clone();
+            let name = &blockchain_corpus.name;
 
             for client_input in &blockchain_corpus.blocks_and_witnesses {
                 let block_number = client_input.block.number;

--- a/crates/zkevm-succinct/host/src/main.rs
+++ b/crates/zkevm-succinct/host/src/main.rs
@@ -27,57 +27,32 @@ fn main() {
     // Setup the prover client.
     let client = ProverClient::from_env();
 
-    let generated = generate();
-    let num_corpuses = generated.len();
+    run_benchmark(
+        STATELESS_ELF,
+        "succinct",
+        |blockchain_corpus: &BlocksAndWitnesses, elf_path: &'static [u8]| {
+            let mut reports = Vec::new();
+            let name = blockchain_corpus.name.clone();
 
-    for (corpus_id, blockchain_corpus) in generated.into_iter().enumerate() {
-        let mut reports = Vec::new();
-        // Iterate each block in the mini blockchain
-        let name = blockchain_corpus.name.clone();
-        let num_blocks_in_corpus = blockchain_corpus.blocks_and_witnesses.len();
+            for client_input in &blockchain_corpus.blocks_and_witnesses {
+                let block_number = client_input.block.number;
+                let mut stdin = SP1Stdin::new();
+                stdin.write(client_input);
+                stdin.write(&blockchain_corpus.network);
 
-        println!("Processing corpus {} / {num_corpuses}", corpus_id + 1);
-        println!("Corpus name: {name}");
-        println!("Num blocks in corpus: {num_blocks_in_corpus}\n");
+                let (_, report) = client.execute(elf_path, &stdin).run().unwrap();
 
-        for (block_id, client_input) in blockchain_corpus.blocks_and_witnesses.iter().enumerate() {
-            println!(
-                "   Processing block {} / {num_blocks_in_corpus}",
-                block_id + 1
-            );
+                let total_num_cycles = report.total_instruction_count();
+                let region_cycles: HashMap<_, _> = report.cycle_tracker.into_iter().collect();
 
-            let block_number = client_input.block.number;
-            let mut stdin = SP1Stdin::new();
-            stdin.write(client_input);
-            stdin.write(&blockchain_corpus.network);
-
-            let (_, report) = client.execute(STATELESS_ELF, &stdin).run().unwrap();
-
-            let total_num_cycles = report.total_instruction_count();
-            let region_cycles: HashMap<_, _> = report.cycle_tracker.into_iter().collect();
-
-            let metrics = WorkloadMetrics {
-                name: format!("{}-{}", name, block_number),
-                total_num_cycles,
-                region_cycles,
-            };
-            reports.push(metrics);
-        }
-
-        WorkloadMetrics::to_path(
-            format!(
-                "{}/{}/{}/{}.json",
-                env!("CARGO_WORKSPACE_DIR"),
-                "zkevm-metrics",
-                "succinct",
-                name
-            ),
-            &reports,
-        )
-        .unwrap();
-
-        // Print out the reports to std for now
-        // We can prettify it later.
-        dbg!(&reports);
-    }
+                let metrics = WorkloadMetrics {
+                    name: format!("{}-{}", name, block_number),
+                    total_num_cycles,
+                    region_cycles,
+                };
+                reports.push(metrics);
+            }
+            reports
+        },
+    );
 }

--- a/crates/zkevm-succinct/host/src/main.rs
+++ b/crates/zkevm-succinct/host/src/main.rs
@@ -1,9 +1,9 @@
 #![doc = include_str!("../../README.md")]
 
-use generate_stateless_witness::generate;
+use benchmark_runner::run_benchmark;
 use sp1_sdk::{ProverClient, SP1Stdin};
 use std::collections::HashMap;
-use witness_generator::generate_stateless_witness;
+use witness_generator::{BlocksAndWitnesses, generate_stateless_witness};
 use zkevm_metrics::WorkloadMetrics;
 
 /// Path to the compiled RISC-V ELF file for the `succinct-guest` crate.

--- a/crates/zkevm-succinct/host/src/main.rs
+++ b/crates/zkevm-succinct/host/src/main.rs
@@ -3,7 +3,7 @@
 use benchmark_runner::run_benchmark;
 use sp1_sdk::{ProverClient, SP1Stdin};
 use std::collections::HashMap;
-use witness_generator::{BlocksAndWitnesses, generate_stateless_witness};
+use witness_generator::BlocksAndWitnesses;
 use zkevm_metrics::WorkloadMetrics;
 
 /// Path to the compiled RISC-V ELF file for the `succinct-guest` crate.

--- a/crates/zkevm-zkm/host/Cargo.toml
+++ b/crates/zkevm-zkm/host/Cargo.toml
@@ -13,6 +13,7 @@ license.workspace = true
 zkm-sdk = { git = "https://github.com/kevaundray/zkMIPS.git", branch = "kw/patch-alloy" }
 witness-generator.workspace = true
 zkevm-metrics.workspace = true
+benchmark-runner.workspace = true
 dotenv = "0.15.0"
 
 [build-dependencies]

--- a/crates/zkevm-zkm/host/src/main.rs
+++ b/crates/zkevm-zkm/host/src/main.rs
@@ -5,7 +5,8 @@ use zkevm_metrics::WorkloadMetrics;
 use zkm_sdk::{ProverClient, ZKMStdin};
 
 use std::collections::HashMap;
-use witness_generator::generate_stateless_witness;
+use witness_generator::BlocksAndWitnesses;
+use zkm_sdk::{ProverClient, ZKMStdin};
 
 /// Path to the compiled MIPS ELF file for the `zkm-guest` crate.
 pub const STATELESS_ELF: &[u8] = include_bytes!(concat!(
@@ -25,55 +26,33 @@ fn main() {
     // Setup the prover client.
     let client = ProverClient::cpu();
 
-    let generated = generate();
-    let num_corpuses = generated.len();
+    run_benchmark(
+        STATELESS_ELF,
+        "zkm",
+        |blockchain_corpus: &BlocksAndWitnesses, elf_path: &'static [u8]| {
+            let mut reports = Vec::new();
+            let name = blockchain_corpus.name.clone();
+            let num_blocks_in_corpus = blockchain_corpus.blocks_and_witnesses.len();
 
-    for (corpus_id, blockchain_corpus) in generated.into_iter().enumerate() {
-        let mut reports = Vec::new();
-        // Iterate each block in the mini blockchain
-        let name = blockchain_corpus.name.clone();
-        let num_blocks_in_corpus = blockchain_corpus.blocks_and_witnesses.len();
+            for client_input in &blockchain_corpus.blocks_and_witnesses {
+                let block_number = client_input.block.number;
+                let mut stdin = ZKMStdin::new();
+                stdin.write(client_input);
+                stdin.write(&blockchain_corpus.network);
 
-        println!("Processing corpus {} / {num_corpuses}", corpus_id + 1);
-        println!("Corpus name: {name}");
-        println!("Num blocks in corpus: {num_blocks_in_corpus}\n");
+                let (_, report) = client.execute(elf_path, stdin).run().unwrap();
 
-        for (block_id, client_input) in blockchain_corpus.blocks_and_witnesses.iter().enumerate() {
-            println!(
-                "   Processing block {} / {num_blocks_in_corpus}",
-                block_id + 1
-            );
+                let total_num_cycles = report.total_instruction_count();
+                let region_cycles: HashMap<_, _> = report.cycle_tracker.into_iter().collect();
 
-            let block_number = client_input.block.number;
-            let mut stdin = ZKMStdin::new();
-            stdin.write(client_input);
-            stdin.write(&blockchain_corpus.network);
-
-            let (_, report) = client.execute(STATELESS_ELF, stdin).run().unwrap();
-
-            let total_num_cycles = report.total_instruction_count();
-            let region_cycles: HashMap<_, _> = report.cycle_tracker.into_iter().collect();
-
-            let metrics = WorkloadMetrics {
-                name: format!("{}-{}", name, block_number),
-                total_num_cycles,
-                region_cycles,
-            };
-            reports.push(metrics);
-        }
-        WorkloadMetrics::to_path(
-            &format!(
-                "{}/{}/{}/{}.json",
-                env!("CARGO_WORKSPACE_DIR"),
-                "zkevm-metrics",
-                "zkm",
-                name
-            ),
-            &reports,
-        )
-        .unwrap();
-        // Print out the reports to std for now
-        // We can prettify it later.
-        dbg!(&reports);
-    }
+                let metrics = WorkloadMetrics {
+                    name: format!("{}-{}", name, block_number),
+                    total_num_cycles,
+                    region_cycles,
+                };
+                reports.push(metrics);
+            }
+            reports
+        },
+    );
 }

--- a/crates/zkevm-zkm/host/src/main.rs
+++ b/crates/zkevm-zkm/host/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
         "zkm",
         |blockchain_corpus: &BlocksAndWitnesses, elf_path: &'static [u8]| {
             let mut reports = Vec::new();
-            let name = blockchain_corpus.name.clone();
+            let name = &blockchain_corpus.name;
             let num_blocks_in_corpus = blockchain_corpus.blocks_and_witnesses.len();
 
             for client_input in &blockchain_corpus.blocks_and_witnesses {


### PR DESCRIPTION
This PR creates a `benchmark-runner` component responsible for parsing the corpus of tests and allows them to be run in parallel.

My motivation is that we now have multiple tests, and zkVM runs them serially (and takes a while). This means that running the whole corpus takes a lot of time.

Running each is independent, so this can give 8x to 16x speedup in running the whole corpus, depending on how many cores you have in your machine. More probably, running the entire corpus reduces to the slowest test in the suite.