### PR TITLE
chore: Add Zisk

### DIFF
--- a/crates/zkevm-zisk/.gitignore
+++ b/crates/zkevm-zisk/.gitignore
@@ -1,0 +1,3 @@
+build
+target
+Cargo.lock

--- a/crates/zkevm-zisk/Cargo.toml
+++ b/crates/zkevm-zisk/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "sha_hasher"
+version = "0.1.0"
+edition = "2021"
+default-run = "sha_hasher"
+
+[dependencies]
+byteorder = "1.5.0"
+sha2 = "0.10.8"
+ziskos = { git = "https://github.com/0xPolygonHermez/zisk.git" }
+
+# reth-ethereum-primitives = { git = "https://github.com/kevaundray/reth", rev = "96de1f325d8835d589bd505b9f94507904f20963" }
+# reth-primitives-traits = { git = "https://github.com/kevaundray/reth", rev = "96de1f325d8835d589bd505b9f94507904f20963" }
+# reth-stateless = { git = "https://github.com/kevaundray/reth", rev = "96de1f325d8835d589bd505b9f94507904f20963" }
+

--- a/crates/zkevm-zisk/build.rs
+++ b/crates/zkevm-zisk/build.rs
@@ -1,0 +1,25 @@
+use std::fs::{self, File};
+use std::io::{self, Write};
+use std::path::Path;
+
+// Define constants for the directory and input file name
+const OUTPUT_DIR: &str = "build/";
+const FILE_NAME: &str = "input.bin";
+
+fn main() -> io::Result<()> {
+    let n: u64 = 20;
+
+    // Ensure the output directory exists
+    let output_dir = Path::new(OUTPUT_DIR);
+    if !output_dir.exists() {
+        // Create the directory and any necessary parent directories
+        fs::create_dir_all(output_dir)?;
+    }
+
+    // Create the file and write the 'n' value in little-endian format
+    let file_path = output_dir.join(FILE_NAME);
+    let mut file = File::create(&file_path)?;
+    file.write_all(&n.to_le_bytes())?;
+
+    Ok(())
+}

--- a/crates/zkevm-zisk/src/main.rs
+++ b/crates/zkevm-zisk/src/main.rs
@@ -1,0 +1,40 @@
+// This example program takes a number `n` as input and computes the SHA-256 hash `n` times sequentially.
+
+// Mark the main function as the entry point for ZisK
+#![no_main]
+ziskos::entrypoint!(main);
+
+use byteorder::ByteOrder;
+use sha2::{Digest, Sha256};
+use std::convert::TryInto;
+use ziskos::{read_input, set_output};
+
+fn main() {
+    // Read the input data as a byte array from ziskos
+    let input: Vec<u8> = read_input();
+
+    // Convert the input data to a u64 integer
+    let n: u64 = match input.try_into() {
+        Ok(input_bytes) => u64::from_le_bytes(input_bytes),
+        Err(input) => panic!(
+            "Invalid input length. Expected 8 bytes, got {}",
+            input.len()
+        ),
+    };
+
+    let mut hash = [0u8; 32];
+
+    // Compute SHA-256 hashing 'n' times
+    for _ in 0..n {
+        let mut hasher = Sha256::new();
+        hasher.update(hash);
+        let digest = &hasher.finalize();
+        hash = Into::<[u8; 32]>::into(*digest);
+    }
+
+    // Split 'hash' value into chunks of 32 bits and write them to ziskos output
+    for i in 0..8 {
+        let val = byteorder::BigEndian::read_u32(&mut hash[i * 4..i * 4 + 4]);
+        set_output(i, val);
+    }
+}


### PR DESCRIPTION
Currently reth requires 1.85 but the zisk guest toolchain is set to 1.84:

```
error: rustc 1.84.0-dev is not supported by the following packages:
  alloy-evm@0.5.0 requires rustc 1.85
  reth-chainspec@1.3.12 requires rustc 1.85
  reth-consensus@1.3.12 requires rustc 1.85
  reth-consensus-common@1.3.12 requires rustc 1.85
  reth-db-models@1.3.12 requires rustc 1.85
  reth-errors@1.3.12 requires rustc 1.85
  reth-ethereum-consensus@1.3.12 requires rustc 1.85
  reth-ethereum-forks@1.3.12 requires rustc 1.85
  reth-ethereum-primitives@1.3.12 requires rustc 1.85
  reth-evm@1.3.12 requires rustc 1.85
  reth-evm-ethereum@1.3.12 requires rustc 1.85
  reth-execution-errors@1.3.12 requires rustc 1.85
  reth-execution-types@1.3.12 requires rustc 1.85
  reth-network-peers@1.3.12 requires rustc 1.85
  reth-primitives@1.3.12 requires rustc 1.85
  reth-primitives-traits@1.3.12 requires rustc 1.85
  reth-prune-types@1.3.12 requires rustc 1.85
  reth-revm@1.3.12 requires rustc 1.85
  reth-stages-types@1.3.12 requires rustc 1.85
  reth-stateless@1.3.12 requires rustc 1.85
  reth-static-file-types@1.3.12 requires rustc 1.85
  reth-storage-api@1.3.12 requires rustc 1.85
  reth-storage-errors@1.3.12 requires rustc 1.85
  reth-trie-common@1.3.12 requires rustc 1.85
  reth-trie-sparse@1.3.12 requires rustc 1.85
Either upgrade rustc or select compatible dependency versions with
`cargo update <name>@<current-ver> --precise <compatible-ver>`
where `<compatible-ver>` is the latest version supporting rustc 1.84.0-dev

Error: Error executing Build command

```