### PR TITLE
chore: update Ere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "log",
  "prettyplease 0.2.32",
  "proc-macro2",
@@ -3038,6 +3038,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
+
+[[package]]
 name = "ere-hosts"
 version = "0.1.0"
 dependencies = [
@@ -3049,7 +3059,7 @@ dependencies = [
 [[package]]
 name = "ere-sp1"
 version = "0.1.0"
-source = "git+https://github.com/eth-applied-research-group/ere#3cb1f39c231889acbd55761f804776c7e43d7ca4"
+source = "git+https://github.com/eth-applied-research-group/ere#74df1a3613fb82c9610a1c9c20f5395b4bc728dc"
 dependencies = [
  "bincode",
  "indexmap 2.9.0",
@@ -8304,7 +8314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -12473,6 +12483,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14068,11 +14084,12 @@ dependencies = [
 [[package]]
 name = "zkvm-interface"
 version = "0.1.0"
-source = "git+https://github.com/eth-applied-research-group/ere#3cb1f39c231889acbd55761f804776c7e43d7ca4"
+source = "git+https://github.com/eth-applied-research-group/ere#74df1a3613fb82c9610a1c9c20f5395b4bc728dc"
 dependencies = [
  "anyhow",
  "auto_impl",
  "bincode",
+ "erased-serde",
  "indexmap 2.9.0",
  "serde",
  "thiserror 2.0.12",


### PR DESCRIPTION
Main change here is that we no longer serialize objects using bincode