### PR TITLE
risc0 getrandom and ere update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,8 +1700,7 @@ dependencies = [
 [[package]]
 name = "blst"
 version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
+source = "git+https://github.com/risc0/blst?tag=v0.3.14-risczero.0#4bb7133be362fce47525dc0c877e058e5a6db5ac"
 dependencies = [
  "cc",
  "glob",
@@ -1813,11 +1812,11 @@ dependencies = [
 [[package]]
 name = "c-kzg"
 version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7318cfa722931cb5fe0838b98d3ce5621e75f6a6408abc21721d80de9223f2e4"
+source = "git+https://github.com/kevaundray/c-kzg-4844.git?branch=kw%2F2.1.1#896141b9406b39e1381bbde318f9ec498e07a13d"
 dependencies = [
  "arbitrary",
  "blst",
+ "bytemuck",
  "cc",
  "glob",
  "hex",
@@ -2222,10 +2221,10 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 [[package]]
 name = "crypto-bigint"
 version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+source = "git+https://github.com/risc0/RustCrypto-crypto-bigint?tag=v0.5.5-risczero.0#3ab63a6f1048833f7047d5a50532e4a4cc789384"
 dependencies = [
  "generic-array 0.14.7",
+ "getrandom 0.2.16",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -2998,7 +2997,7 @@ dependencies = [
 [[package]]
 name = "ere-risczero"
 version = "0.1.0"
-source = "git+https://github.com/eth-applied-research-group/ere#d106f8d65c103c27e23e3cd7ba6a0e8eb7364c78"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=5f4fe5e7a83c969cab160b10644330ab771ee94c#5f4fe5e7a83c969cab160b10644330ab771ee94c"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3014,7 +3013,7 @@ dependencies = [
 [[package]]
 name = "ere-sp1"
 version = "0.1.0"
-source = "git+https://github.com/eth-applied-research-group/ere#d106f8d65c103c27e23e3cd7ba6a0e8eb7364c78"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=5f4fe5e7a83c969cab160b10644330ab771ee94c#5f4fe5e7a83c969cab160b10644330ab771ee94c"
 dependencies = [
  "bincode",
  "indexmap 2.9.0",
@@ -4493,13 +4492,14 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?tag=k256%2Fv0.13.4-risczero.1#7d4a8d6477e258ce4169ee4669cf92aee0582c39"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
  "once_cell",
+ "risc0-bigint2",
  "serdect",
  "sha2 0.10.8",
  "signature",
@@ -5464,12 +5464,13 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p256"
 version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?tag=p256%2Fv0.13.2-risczero.1#bb0f51ad3ba81585f36ea8a1ea81093d8664b195"
 dependencies = [
+ "bytemuck",
  "ecdsa",
  "elliptic-curve",
  "primeorder",
+ "risc0-bigint2",
  "sha2 0.10.8",
 ]
 
@@ -6169,11 +6170,12 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+version = "0.13.1"
+source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?tag=p256%2Fv0.13.2-risczero.1#bb0f51ad3ba81585f36ea8a1ea81093d8664b195"
 dependencies = [
+ "bytemuck",
  "elliptic-curve",
+ "risc0-bigint2",
 ]
 
 [[package]]
@@ -8368,6 +8370,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-bigint2"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921e2d3d07a327750f657c0d42cf9437024583b218ad05b24b91a557f5d01979"
+dependencies = [
+ "include_bytes_aligned",
+ "stability",
+]
+
+[[package]]
 name = "risc0-binfmt"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9198,8 +9210,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+source = "git+https://github.com/risc0/RustCrypto-hashes?tag=sha2-v0.10.8-risczero.0#244dc3b08788f7a4ccce14c66896ae3b4f24c166"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -9946,13 +9957,15 @@ dependencies = [
 [[package]]
 name = "substrate-bn"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
+source = "git+https://github.com/risc0/paritytech-bn?tag=v0.6.0-risczero.0#22108fe8c6ea1ebc1358fc4fd6854a6bf46e3509"
 dependencies = [
+ "bytemuck",
  "byteorder",
  "crunchy",
+ "crypto-bigint",
  "lazy_static",
  "rand 0.8.5",
+ "risc0-bigint2",
  "rustc-hex",
 ]
 
@@ -10178,8 +10191,7 @@ dependencies = [
 [[package]]
 name = "tiny-keccak"
 version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+source = "git+https://github.com/risc0/tiny-keccak?tag=tiny-keccak%2Fv2.0.2-risczero.0#8fcc866dc94dcec3e79c3b2bc8fbc51b22f2d5e1"
 dependencies = [
  "crunchy",
 ]
@@ -11833,7 +11845,7 @@ dependencies = [
 [[package]]
 name = "zkvm-interface"
 version = "0.1.0"
-source = "git+https://github.com/eth-applied-research-group/ere#d106f8d65c103c27e23e3cd7ba6a0e8eb7364c78"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=5f4fe5e7a83c969cab160b10644330ab771ee94c#5f4fe5e7a83c969cab160b10644330ab771ee94c"
 dependencies = [
  "anyhow",
  "auto_impl",
@@ -11871,3 +11883,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "bls12_381"
+version = "0.8.0"
+source = "git+https://github.com/risc0/zkcrypto-bls12_381?tag=bls12_381%2Fv0.8.0-risczero.1#a3192e1bc58921d42d03d99957abf3be55f9d435"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,11 +111,11 @@ witness-generator = { path = "crates/witness-generator" }
 zkevm-metrics = { path = "crates/metrics" }
 benchmark-runner = { path = "crates/benchmark-runner" }
 
-zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", package = "zkvm-interface" }
-ere-sp1 = { git = "https://github.com/eth-applied-research-group/ere", package = "ere-sp1" }
-ere-risczero = { git = "https://github.com/eth-applied-research-group/ere", package = "ere-risczero" }
-ere-pico = { git = "https://github.com/eth-applied-research-group/ere", package = "ere-pico" }
-ere-openvm = { git = "https://github.com/eth-applied-research-group/ere", package = "ere-openvm" }
+zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", rev = "5f4fe5e7a83c969cab160b10644330ab771ee94c", package = "zkvm-interface" }
+ere-sp1 = { git = "https://github.com/eth-applied-research-group/ere", rev = "5f4fe5e7a83c969cab160b10644330ab771ee94c", package = "ere-sp1" }
+ere-risczero = { git = "https://github.com/eth-applied-research-group/ere", rev = "5f4fe5e7a83c969cab160b10644330ab771ee94c", package = "ere-risczero" }
+ere-pico = { git = "https://github.com/eth-applied-research-group/ere", rev = "5f4fe5e7a83c969cab160b10644330ab771ee94c", package = "ere-pico" }
+ere-openvm = { git = "https://github.com/eth-applied-research-group/ere", rev = "5f4fe5e7a83c969cab160b10644330ab771ee94c", package = "ere-openvm" }
 
 # branch is kw/zkevm-benchmark-workload-repo
 # NOTE: We are using a branch of a branch that has not yet been merged into master.

--- a/crates/benchmark-runner/src/lib.rs
+++ b/crates/benchmark-runner/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::*;
 use rayon::prelude::*;
-use std::{collections::HashMap, fs, panic, sync::Arc};
+use std::{fs, panic, sync::Arc};
 use witness_generator::{witness_generator::WitnessGenerator, BlocksAndWitnesses};
 use zkevm_metrics::WorkloadMetrics;
 use zkvm_interface::{zkVM, Input};
@@ -189,11 +189,11 @@ where
         let workload_metrics = match action {
             Action::Execute => {
                 let report = zkvm_ref.execute(&stdin)?;
-                let region_cycles: HashMap<_, _> = report.region_cycles.into_iter().collect();
                 WorkloadMetrics::Execution {
                     name: format!("{}-{}", bw.name, block_number),
                     total_num_cycles: report.total_num_cycles,
-                    region_cycles,
+                    region_cycles: report.region_cycles.into_iter().collect(),
+                    execution_duration: report.execution_duration,
                 }
             }
             Action::Prove => {

--- a/crates/metrics/README.md
+++ b/crates/metrics/README.md
@@ -34,6 +34,7 @@ use zkevm_metrics::WorkloadMetrics;
 use std::collections::HashMap;
 use std::iter::FromIterator;
 use std::env::temp_dir;
+use std::time::Duration;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let metrics_data = vec![
@@ -45,6 +46,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 ("compute".to_string(), 800),
                 ("teardown".to_string(), 100),
             ]),
+            execution_duration: Duration::from_millis(300),
         },
         // ... other workloads
     ];

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 use serde_derive::{Deserialize, Serialize};
-use std::{collections::HashMap, fs, io, path::Path};
+use std::{collections::HashMap, fs, io, path::Path, time::Duration};
 use thiserror::Error;
 
 /// Cycle-count metrics for a particular workload.
@@ -17,6 +17,8 @@ pub enum WorkloadMetrics {
         total_num_cycles: u64,
         /// Region-specific cycles, mapping region names (e.g., "setup", "compute") to their cycle counts.
         region_cycles: HashMap<String, u64>,
+        /// Execution duration.
+        execution_duration: Duration,
     },
     /// Metrics produced when benchmarking in proving mode
     Proving {

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -139,6 +139,7 @@ mod tests {
                     ("compute".to_string(), 800),
                     ("teardown".to_string(), 100),
                 ]),
+                execution_duration: Duration::from_millis(150),
             },
             WorkloadMetrics::Execution {
                 name: "aes".into(),
@@ -148,6 +149,7 @@ mod tests {
                     ("encrypt".to_string(), 1_600),
                     ("final".to_string(), 200),
                 ]),
+                execution_duration: Duration::from_millis(300),
             },
             WorkloadMetrics::Proving {
                 name: "rsa".into(),
@@ -202,6 +204,7 @@ mod tests {
             name: "test_execution".into(),
             total_num_cycles: 1000,
             region_cycles: HashMap::new(),
+            execution_duration: Duration::from_millis(150),
         };
 
         let proving_metric = WorkloadMetrics::Proving {
@@ -227,6 +230,7 @@ mod tests {
                 name: "mixed_execution".into(),
                 total_num_cycles: 500,
                 region_cycles: HashMap::from_iter([("phase1".to_string(), 500)]),
+                execution_duration: Duration::from_millis(200),
             },
             WorkloadMetrics::Proving {
                 name: "mixed_proving".into(),

--- a/ere-guests/risc0/guest/Cargo.toml
+++ b/ere-guests/risc0/guest/Cargo.toml
@@ -23,6 +23,7 @@ revm = { version = "23", features = ["std", "c-kzg", "blst", "bn"] }
 risc0-zkvm = { version = "^2.0.2", default-features = false, features = [
     "std",
     "unstable",
+    "getrandom",
 ] }
 
 sha2 = "=0.10.8"


### PR DESCRIPTION
This PR:
- Updates `ere` and pins to a specific commit (latest now), so we don't have a non-well defined dependency target in case of breaking changes happening.
- Fixes risc0 guest program to allow for `getrandom` feature.

The last bullet was discovered when I tried to run mainnet blocks with risc0 and got this panic:
```
thread 'main' panicked at /home/ignacio/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/risc0-zkvm-platform-2.0.2/src/getrandom.rs:63:5:


WARNING: `getrandom()` called from guest.
=========================================

This panic was generated from the guest program calling `getrandom()`.
Using randomness in the zkVM requires careful attention to your
application’s security requirements. Therefore, the default behavior is
for the zkVM to generate this panic message when the guest calls
`getrandom()`. If you wrote this guest program, it is crucial that you
understand the implications of using randomness in your guest code and
make changes to fit your needs.


The zkVM supports providing random data from the host in response to
`getrandom()`. When the randomness is being used to protect private data, this
is a good option. However, it is not appropriate for all use cases. Consider a
situation when random data is needed to ensure the honesty of the prover (e.g.
to flip a coin for a game between the prover and verifier). In this scenario,
host provided randomness is not suitable because the prover may alter the source
of randomness. For such use cases, great care must be taken to provide a source
of randomness that the prover cannot manipulate or predict. Host provided
randomness can be enabled with the `getrandom` feature flag on the `risc0-zkvm`
crate used for the guest.


note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Benchmark CRASHED for mainnet_block_22639757: Error: Guest panicked: 

WARNING: `getrandom()` called from guest.
=========================================

This panic was generated from the guest program calling `getrandom()`.
Using randomness in the zkVM requires careful attention to your
application’s security requirements. Therefore, the default behavior is
for the zkVM to generate this panic message when the guest calls
`getrandom()`. If you wrote this guest program, it is crucial that you
understand the implications of using randomness in your guest code and
make changes to fit your needs.


The zkVM supports providing random data from the host in response to
`getrandom()`. When the randomness is being used to protect private data, this
is a good option. However, it is not appropriate for all use cases. Consider a
situation when random data is needed to ensure the honesty of the prover (e.g.
to flip a coin for a game between the prover and verifier). In this scenario,
host provided randomness is not suitable because the prover may alter the source
of randomness. For such use cases, great care must be taken to provide a source
of randomness that the prover cannot manipulate or predict. Host provided
randomness can be enabled with the `getrandom` feature flag on the `risc0-zkvm`
crate used for the guest.
```

The message is quite clear, but if you are interested in what is happening under the hood here's what I found:
- The [`getrandom` crate](https://docs.rs/getrandom/0.3.3/getrandom) has a [special feature `custom`](https://docs.rs/getrandom/0.3.3/getrandom/#opt-in-backends) to allow arbitrary implementations.
- The build package of risc0 [uses this compilation flag](https://github.com/risc0/risc0/blob/main/risc0/build/src/lib.rs#L493) to enable the feature. So it has to implement that [custom backend](https://docs.rs/getrandom/0.3.3/getrandom/#custom-backend).
- If you enable the `getrandom` feature of `zkvm-platform`, you change that [custom backend implementation](https://github.com/risc0/risc0/blob/main/risc0/zkvm/platform/src/getrandom.rs#L17-L91). As you can see there, since isn't enabled by default that last link has the panic message that I showed before. If you enable it, then puts an implementation that calls the `sys_rand` syscall.

All makes sense as a way to control if the `sys_rand` syscall is allowed. Was quite cool to discover that the `getrandom` craate (which is a public crate) allows to set custom backends that could wire all this.

From our repo side just enabling `getrandom` is the fix and now we can execute mainnet blocks. I would like to eventually dig why for running test cases this wasn't happening, but probably there's a reasonable explanation.