### PR TITLE
Generate witness once before running benchmarks

### DIFF
--- a/crates/benchmark-runner/src/lib.rs
+++ b/crates/benchmark-runner/src/lib.rs
@@ -51,18 +51,16 @@ pub enum Action {
     Execute,
 }
 
-pub async fn run_benchmark_ere<V>(
+pub fn run_benchmark_ere<V>(
     host_name: &str,
     zkvm_instance: V,
     action: Action,
-    wg: &Box<dyn WitnessGenerator>,
-) -> Result<()>
-where
+    corpuses: &[BlocksAndWitnesses],
+) where
     V: zkVM + Sync,
 {
     println!("Benchmarking `{}`…", host_name);
     let zkvm_ref = Arc::new(&zkvm_instance);
-    let corpuses = wg.generate().await?;
 
     match action {
         Action::Execute => {
@@ -78,12 +76,10 @@ where
             });
         }
     }
-
-    Ok(())
 }
 
 fn process_corpus_with_crash_handling<V>(
-    bw: BlocksAndWitnesses,
+    bw: &BlocksAndWitnesses,
     zkvm_ref: Arc<&V>,
     action: &Action,
     host_name: &str,
@@ -160,7 +156,7 @@ fn process_corpus_with_crash_handling<V>(
 }
 
 fn process_corpus<V>(
-    mut bw: BlocksAndWitnesses,
+    bw: &BlocksAndWitnesses,
     zkvm_ref: Arc<&V>,
     action: &Action,
     host_name: &str,
@@ -175,12 +171,12 @@ where
         None => panic!("unexpected test with no blocks {}", &bw.name),
     };
 
-    bw.blocks_and_witnesses = vec![last_block_with_witness];
+    let blocks_and_witnesses = vec![last_block_with_witness];
 
-    println!(" {} ({} blocks)", bw.name, bw.blocks_and_witnesses.len());
+    println!(" {} ({} blocks)", bw.name, blocks_and_witnesses.len());
     let mut reports = Vec::new();
 
-    for ci in bw.blocks_and_witnesses {
+    for ci in blocks_and_witnesses {
         let block_number = ci.block.number;
         let mut stdin = Input::new();
         stdin.write(ci);

--- a/crates/ere-hosts/src/main.rs
+++ b/crates/ere-hosts/src/main.rs
@@ -144,7 +144,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let corpuses = block_witness_gen.generate().await?;
 
-
     // Set to true once a zkvm has ran
     let mut ran_any = false;
 

--- a/crates/ere-hosts/src/main.rs
+++ b/crates/ere-hosts/src/main.rs
@@ -43,7 +43,7 @@ enum SourceCommand {
         #[arg(short, long, default_value = "zkevm-fixtures/fixtures")]
         directory_path: String,
     },
-    Mainnet {
+    Rpc {
         /// Number of last blocks to pull from mainnet (mandatory)
         #[arg(long)]
         last_n_blocks: usize,
@@ -116,7 +116,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         SourceCommand::Tests { directory_path } => {
             Box::new(ExecSpecTestBlocksAndWitnesses::new(directory_path.into()))
         }
-        SourceCommand::Mainnet {
+        SourceCommand::Rpc {
             last_n_blocks,
             rpc_url,
             rpc_header,
@@ -142,17 +142,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
+    let corpuses = block_witness_gen.generate().await?;
+
     for zkvm in zkvms {
         match zkvm {
             zkVM::Sp1 => {
                 run_cargo_patch_command("sp1")?;
                 let sp1_zkvm = new_sp1_zkvm(resource)?;
-                run_benchmark_ere("sp1", sp1_zkvm, action, &block_witness_gen).await?;
+                run_benchmark_ere("sp1", sp1_zkvm, action, &corpuses);
             }
             zkVM::Risc0 => {
                 run_cargo_patch_command("risc0")?;
                 let risc0_zkvm = new_risczero_zkvm(resource)?;
-                run_benchmark_ere("risc0", risc0_zkvm, action, &block_witness_gen).await?;
+                run_benchmark_ere("risc0", risc0_zkvm, action, &corpuses);
             } // zkVM::Openvm => {
               //     run_cargo_patch_command("openvm")?;
               //     let openvm_zkvm = new_openvm_zkvm(resource)?;


### PR DESCRIPTION
I was running benchmarks for two zkVMs for mainnet blocks and I realized the way things were wasn't ideal.

The witness generation call was done on each benchmark zkVM run, which for mainnet blocks means each will pull different blocks since we pul the last N blocks.

This PR changes the logic to generate the witness once, and use the same corpus on each zkVM. This also avoid generating witnesses repeatedly which would speed up benchmarks a bit too. And also, is a small step in the direction of untangling witness generation from benchmark runs (e.g. new benchmark running is not async again).